### PR TITLE
F2 — Roles MVP: operario + administrador

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -86,7 +86,8 @@ class UserController extends Controller
                 'email' => $request->email,
                 'password' => $request->password,
             ]);
-            $nuevoUsuario->save();            
+            $nuevoUsuario->role = User::ROLE_ADMIN;
+            $nuevoUsuario->save();
             DB::commit();           
            
             Auth::login($nuevoUsuario);

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -61,6 +61,7 @@ class Kernel extends HttpKernel
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
         'precognitive' => \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
+        'role' => \App\Http\Middleware\EnsureRole::class,
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,

--- a/app/Http/Middleware/EnsureRole.php
+++ b/app/Http/Middleware/EnsureRole.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureRole
+{
+    /**
+     * Handle an incoming request.
+     *
+     * Usage in routes: ->middleware('role:administrador')
+     *                  ->middleware('role:operario,administrador')
+     */
+    public function handle(Request $request, Closure $next, string ...$roles): Response
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return redirect()->route('login');
+        }
+
+        if (! in_array($user->role, $roles, true)) {
+            abort(403, 'No tienes permiso para acceder a esta sección.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,6 +14,9 @@ class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;
 
+    public const ROLE_ADMIN = 'administrador';
+    public const ROLE_OPERARIO = 'operario';
+
     /**
      * The attributes that are mass assignable.
      *
@@ -44,4 +47,19 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    public function isAdmin(): bool
+    {
+        return $this->role === self::ROLE_ADMIN;
+    }
+
+    public function isOperario(): bool
+    {
+        return $this->role === self::ROLE_OPERARIO;
+    }
+
+    public function hasRole(string $role): bool
+    {
+        return $this->role === $role;
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,9 +4,11 @@ namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\Blade;
 use App\Models\Productos;
 use App\Models\Categorias;
 use App\Models\Almacenes;
+use App\Models\User;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Auth;
 
@@ -34,5 +36,9 @@ class AppServiceProvider extends ServiceProvider
         if (app()->environment('production')) {
             $this->app['request']->server->set('HTTPS', 'on');
         }
+
+        Blade::if('admin', fn () => Auth::check() && Auth::user()->isAdmin());
+        Blade::if('operario', fn () => Auth::check() && Auth::user()->isOperario());
+        Blade::if('role', fn (string $role) => Auth::check() && Auth::user()->hasRole($role));
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -29,6 +30,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'role' => User::ROLE_ADMIN,
         ];
     }
 
@@ -40,5 +42,15 @@ class UserFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
         ]);
+    }
+
+    public function operario(): static
+    {
+        return $this->state(fn () => ['role' => User::ROLE_OPERARIO]);
+    }
+
+    public function administrador(): static
+    {
+        return $this->state(fn () => ['role' => User::ROLE_ADMIN]);
     }
 }

--- a/database/migrations/2026_05_08_000001_add_role_to_users_table.php
+++ b/database/migrations/2026_05_08_000001_add_role_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role', 20)->default('administrador')->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/database/seeders/DemoDataSeeder.php
+++ b/database/seeders/DemoDataSeeder.php
@@ -17,20 +17,31 @@ class DemoDataSeeder extends Seeder
      */
     public function run(): void
     {
-        // Crear usuario demo
+        // Administrador de demostración (gestiona almacenes y categorías)
         $demoUser = User::create([
-            'name' => 'Demo User',
+            'name' => 'Demo Admin',
             'email' => 'demo@inventario.com',
             'email_verified_at' => now(),
             'password' => Hash::make('demo123'),
+            'role' => User::ROLE_ADMIN,
         ]);
 
-        // Crear segundo usuario para mostrar multi-tenancy
+        // Segundo administrador para validar multi-tenancy
         $adminUser = User::create([
             'name' => 'Admin User',
             'email' => 'admin@inventario.com',
             'email_verified_at' => now(),
             'password' => Hash::make('admin123'),
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        // Operario que sólo registra/escanea productos del Demo Admin
+        $operarioUser = User::create([
+            'name' => 'Operario Demo',
+            'email' => 'operario@inventario.com',
+            'email_verified_at' => now(),
+            'password' => Hash::make('operario123'),
+            'role' => User::ROLE_OPERARIO,
         ]);
 
         // Crear almacenes para demo user
@@ -251,8 +262,9 @@ class DemoDataSeeder extends Seeder
         ]);
 
         $this->command->info('✅ Datos de ejemplo creados exitosamente:');
-        $this->command->info('📧 Usuario Demo: demo@inventario.com / demo123');
-        $this->command->info('📧 Usuario Admin: admin@inventario.com / admin123');
+        $this->command->info('📧 Demo Admin: demo@inventario.com / demo123');
+        $this->command->info('📧 Admin tenant 2: admin@inventario.com / admin123');
+        $this->command->info('📧 Operario: operario@inventario.com / operario123');
         $this->command->info('📦 ' . (count($productos) + 1) . ' productos creados');
         $this->command->info('🏢 3 almacenes creados');
         $this->command->info('📋 6 categorías creadas');

--- a/tests/Feature/RolesTest.php
+++ b/tests/Feature/RolesTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class RolesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_signup_assigns_administrador_role_by_default(): void
+    {
+        $this->post('/signup', [
+            'email' => 'new@cdepot.test',
+            'password' => 'password123',
+        ])->assertRedirect('/');
+
+        $user = User::where('email', 'new@cdepot.test')->first();
+        $this->assertNotNull($user);
+        $this->assertSame(User::ROLE_ADMIN, $user->role);
+        $this->assertTrue($user->isAdmin());
+        $this->assertFalse($user->isOperario());
+    }
+
+    public function test_role_middleware_blocks_wrong_role(): void
+    {
+        Route::middleware(['auth', 'role:administrador'])->get('/__test_admin_only', fn () => 'ok');
+
+        $operario = User::factory()->create(['role' => User::ROLE_OPERARIO]);
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+
+        $this->actingAs($operario)->get('/__test_admin_only')->assertForbidden();
+        $this->actingAs($admin)->get('/__test_admin_only')->assertOk();
+    }
+
+    public function test_role_middleware_accepts_multiple_roles(): void
+    {
+        Route::middleware(['auth', 'role:operario,administrador'])->get('/__test_any', fn () => 'ok');
+
+        $this->actingAs(User::factory()->create(['role' => User::ROLE_OPERARIO]))
+            ->get('/__test_any')->assertOk();
+        $this->actingAs(User::factory()->create(['role' => User::ROLE_ADMIN]))
+            ->get('/__test_any')->assertOk();
+    }
+
+    public function test_unauthenticated_user_redirects_to_login(): void
+    {
+        Route::middleware(['auth', 'role:administrador'])->get('/__test_unauth', fn () => 'ok');
+        $this->get('/__test_unauth')->assertRedirect('/login');
+    }
+}


### PR DESCRIPTION
## Resumen

Sistema de roles minimalista (operario + administrador). **Base: \`work/tooling-base\` (PR #12)**, no \`main\` — F2 depende de F1.

### Cambios

- **Migración \`add_role_to_users_table\`**: columna `role` string(20) con default `administrador` (preserva acceso de usuarios existentes).
- **`User` model**: constantes `ROLE_ADMIN`, `ROLE_OPERARIO`. Helpers `isAdmin()`, `isOperario()`, `hasRole(string)`.
- **`EnsureRole` middleware** (alias `role`): uso en rutas `->middleware('role:administrador')` o `->middleware('role:operario,administrador')`. Aborta 403 si el rol no coincide; redirect a login si no autenticado.
- **Directivas Blade `@admin`, `@operario`, `@role('x')`**: para condicionales por rol en vistas (uso en F5 cuando rediseñemos navbar/sidebar).
- **Signup asigna `administrador` por default** — comportamiento conservador. Operarios se crean desde seeder o (futuro) panel admin.
- **`UserFactory`** con `role` por defecto + states `->operario()`, `->administrador()`.
- **`DemoDataSeeder`** ahora crea un operario adicional `operario@inventario.com / operario123`.
- **Tests Feature** cubren: signup default, middleware bloquea rol incorrecto, acepta múltiples roles, redirect login si no auth.

## Test plan

- [ ] CI verde
- [ ] `php artisan migrate` aplica la migración sin romper tablas existentes
- [ ] `php artisan db:seed --class=DemoDataSeeder` crea los 3 usuarios con roles
- [ ] Tests de RolesTest pasan (4 tests)

## Lo que NO entra (siguiente fase)

- Aplicación del middleware `role` a rutas reales (el dashboard segmentado y el bloqueo de admin-only va en F6 cuando reformamos las vistas).
- Panel de gestión de usuarios para que el admin cree operarios.
- UI diferenciada por rol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)