### PR TITLE
F3.5 — Cierre de cross-tenant leak en images y categorias

### DIFF
--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use GuzzleHttp\Client;
 use App\Models\Images;
+use App\Models\Productos;
 
 class APIController extends Controller
 {
@@ -34,11 +35,12 @@ class APIController extends Controller
     }
 
     public function showImage($id)
-        {
-            $image = Images::findOrFail($id);
+    {
+        $image = Images::findOrFail($id);
+        $producto = Productos::findOrFail($image->id_producto);
+        abort_if($producto->id_user !== auth()->id(), 403);
 
-            // Devolver la imagen como respuesta HTTP
-            return response($image->data)->header('Content-Type', $image->mime_type);
-        }
+        return redirect($image->url);
+    }
 
 }

--- a/app/Http/Controllers/ProductosController.php
+++ b/app/Http/Controllers/ProductosController.php
@@ -26,16 +26,17 @@ class ProductosController extends Controller
     public function index()
     {
         $userId = auth()->id();
-        $categorias = Categorias::where('id_user', $userId)->get();            
+        $categorias = Categorias::where('id_user', $userId)->get();
         $almacenes = Almacenes::where('id_user', $userId)->get();
-        $productosCategorias = Productos_has_categorias::all();
-        $imagenes = Images::all();
         $productos = Productos::where('id_user', $userId)
                                 ->orderBy('nombre', 'asc')
                                 ->paginate(12);
+        $productoIds = Productos::where('id_user', $userId)->pluck('id');
+        $productosCategorias = Productos_has_categorias::whereIn('id_producto', $productoIds)->get();
+        $imagenes = Images::whereIn('id_producto', $productoIds)->get();
         return view('pages.productos.pizarra', compact(
-            'productos', 
-            'categorias', 'almacenes', 'productosCategorias', 'imagenes')); 
+            'productos',
+            'categorias', 'almacenes', 'productosCategorias', 'imagenes'));
     }
 
     public function create()
@@ -128,16 +129,18 @@ class ProductosController extends Controller
                                     ->paginate(12);
         }
         $filtro = $request->input('filtro');
-        $categorias = Categorias::where('id_user', $userId)->get();            
+        $categorias = Categorias::where('id_user', $userId)->get();
         $almacenes = Almacenes::where('id_user', $userId)->get();
-        $productosCategorias = Productos_has_categorias::all();
-        
-        
+        $productoIds = Productos::where('id_user', $userId)->pluck('id');
+        $productosCategorias = Productos_has_categorias::whereIn('id_producto', $productoIds)->get();
+        $imagenes = Images::whereIn('id_producto', $productoIds)->get();
+
         $productosHtml = view('panels.productTable')
         ->with('productos', $productos)
         ->with('categorias', $categorias)
         ->with('almacenes', $almacenes)
         ->with('productosCategorias', $productosCategorias)
+        ->with('imagenes', $imagenes)
         ->render();
 
       
@@ -171,14 +174,17 @@ class ProductosController extends Controller
                                     ->where('nombre', 'like', '%' . $request->q . '%')
                                     ->orderBy('nombre', 'asc')
                                     ->paginate(12);
-            $categorias = Categorias::where('id_user', $userId)->get();            
+            $categorias = Categorias::where('id_user', $userId)->get();
             $almacenes = Almacenes::where('id_user', $userId)->get();
-            $productosCategorias = Productos_has_categorias::all();
+            $productoIds = Productos::where('id_user', $userId)->pluck('id');
+            $productosCategorias = Productos_has_categorias::whereIn('id_producto', $productoIds)->get();
+            $imagenes = Images::whereIn('id_producto', $productoIds)->get();
             $productosHtml = view('panels.productTable')
             ->with('productos', $productos)
             ->with('categorias', $categorias)
             ->with('almacenes', $almacenes)
             ->with('productosCategorias', $productosCategorias)
+            ->with('imagenes', $imagenes)
             ->render();
     
           
@@ -200,10 +206,10 @@ class ProductosController extends Controller
         $userId = auth()->id();
         $producto = Productos::findOrFail($id);
         abort_if($producto->id_user !== $userId, 403);
-        $categorias = Categorias::where('id_user', $userId)->get();            
+        $categorias = Categorias::where('id_user', $userId)->get();
         $almacenes = Almacenes::where('id_user', $userId)->get();
         $modo = 'editar';
-        $productosCategorias = Productos_has_categorias::all();
+        $productosCategorias = Productos_has_categorias::where('id_producto', $producto->id)->get();
         $categoriasRelacionadas = $productosCategorias->pluck('id_categoria')->toArray();
         foreach ($categorias as $categoria) {
             $categoria->relationExists = $productosCategorias->contains(function ($value) use ($categoria, $producto) {
@@ -218,10 +224,10 @@ class ProductosController extends Controller
         $userId = auth()->id();
         $producto = Productos::findOrFail($id);
         abort_if($producto->id_user !== $userId, 403);
-        $categorias = Categorias::where('id_user', $userId)->get();            
+        $categorias = Categorias::where('id_user', $userId)->get();
         $almacenes = Almacenes::where('id_user', $userId)->get();
         $modo = 'editar';
-        $productosCategorias = Productos_has_categorias::all();
+        $productosCategorias = Productos_has_categorias::where('id_producto', $producto->id)->get();
         $categoriasRelacionadas = $productosCategorias->pluck('id_categoria')->toArray();
         foreach ($categorias as $categoria) {
             $categoria->relationExists = $productosCategorias->contains(function ($value) use ($categoria, $producto) {
@@ -289,11 +295,11 @@ class ProductosController extends Controller
     public function filterOptions(Request $request)
     {
         $userId = auth()->id();
-        $filtro = $request->query('filtro');       
-        $categorias = Categorias::where('id_user', $userId)->get();            
+        $filtro = $request->query('filtro');
+        $categorias = Categorias::where('id_user', $userId)->get();
         $almacenes = Almacenes::where('id_user', $userId)->get();
-        $productosCategorias = Productos_has_categorias::all();
         $productos = Productos::where('id_user', $userId)->get();
+        $productosCategorias = Productos_has_categorias::whereIn('id_producto', $productos->pluck('id'))->get();
         return view('pages.productos.pizarra', compact('productos', 'categorias', 'almacenes', 'productosCategorias', 'filtro')); 
 
     }

--- a/tests/Feature/CrossTenantIsolationTest.php
+++ b/tests/Feature/CrossTenantIsolationTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Almacenes;
+use App\Models\Categorias;
+use App\Models\Images;
+use App\Models\Productos;
+use App\Models\Productos_has_categorias;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CrossTenantIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeProduct(User $owner, ?Almacenes $almacen = null, ?Categorias $categoria = null): Productos
+    {
+        $almacen ??= Almacenes::factory()->create(['id_user' => $owner->id]);
+        $categoria ??= Categorias::factory()->create(['id_user' => $owner->id]);
+
+        $producto = Productos::factory()->create([
+            'id_user' => $owner->id,
+            'almacen' => $almacen->id,
+        ]);
+
+        Productos_has_categorias::create([
+            'id_producto' => $producto->id,
+            'id_categoria' => $categoria->id,
+        ]);
+
+        Images::create([
+            'nombre' => 'foto',
+            'url' => "https://cdn.example/{$producto->id}.jpg",
+            'id_producto' => $producto->id,
+        ]);
+
+        return $producto;
+    }
+
+    public function test_index_does_not_expose_other_tenant_images_or_categories(): void
+    {
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        $this->makeProduct($userA);
+        $foreign = $this->makeProduct($userB);
+
+        $response = $this->actingAs($userA)->get('/productos');
+
+        $response->assertOk();
+        $response->assertViewHas('imagenes', function ($imagenes) use ($foreign) {
+            return ! $imagenes->contains('id_producto', $foreign->id);
+        });
+        $response->assertViewHas('productosCategorias', function ($rels) use ($foreign) {
+            return ! $rels->contains('id_producto', $foreign->id);
+        });
+    }
+
+    public function test_show_search_does_not_leak_foreign_products(): void
+    {
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        Productos::factory()->create(['id_user' => $userA->id, 'nombre' => 'mio especial']);
+        Productos::factory()->create(['id_user' => $userB->id, 'nombre' => 'mio especial ajeno']);
+
+        $response = $this->actingAs($userA)->post('/productos', [
+            'termino' => 'mio especial',
+        ]);
+
+        $response->assertOk();
+        $body = $response->json();
+        $this->assertCount(1, $body['productos']['data']);
+        $this->assertSame('mio especial', $body['productos']['data'][0]['nombre']);
+    }
+
+    public function test_show_image_endpoint_blocks_foreign_image(): void
+    {
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        $foreignProduct = $this->makeProduct($userB);
+        $foreignImage = Images::where('id_producto', $foreignProduct->id)->first();
+
+        $this->actingAs($userA)->get("/images/{$foreignImage->id}")->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Resumen

Cierra el último vector de fuga inter-tenant que el security-auditor identificó al analizar el modo demo. **Bloqueo previo a F4 (QR local) y a F13.5 (modo demo público)**.

### El problema

\`Images::all()\` y \`Productos_has_categorias::all()\` devolvían filas de **todos los tenants** en cada llamada. La pizarra de productos sólo mostraba lo que pertenecía al usuario gracias al filtro JS sobre el dataset, pero el dataset enviado al cliente incluía URLs de Cloudinary y relaciones categoría-producto de cuentas ajenas. \`APIController::showImage\` también permitía leer cualquier imagen por ID sin verificar ownership (además del bug latente de leer columnas \`data\`/\`mime_type\` que no existen en el schema).

### Cambios

- **\`ProductosController\`** (`index`, `show`, `display`, `edit`, `detail`, `filterOptions`): cada query de `Images::all()` y `Productos_has_categorias::all()` ahora se filtra por `whereIn('id_producto', $productos_del_user)`. En `edit`/`detail` se filtra al producto concreto.
- **\`APIController::showImage\`**: ownership check via `id_producto → productos.id_user`. Cambia el tipo de respuesta a `redirect()` hacia la URL de Cloudinary (la implementación anterior leía columnas inexistentes).
- **3 Feature tests**:
  - `index` no expone imágenes ni relaciones categoría-producto de otro tenant
  - `POST /productos` (search) no leakea productos ajenos
  - `GET /images/{id}` con imagen de otro user → 403

## Test plan

- [ ] CI verde
- [ ] Pizarra de productos sigue mostrando QRs y categorías propios
- [ ] User A no ve productos / imágenes de User B en ningún endpoint

## Próxima fase

F4 — generación de QR local con \`endroid/qr-code\` para eliminar dependencia de RapidAPI y Cloudinary upload del QR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)