### PR TITLE
F4 — QR local con endroid (sin RapidAPI ni Cloudinary)

### DIFF
--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -2,38 +2,12 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-use GuzzleHttp\Client;
 use App\Models\Images;
 use App\Models\Productos;
+use Illuminate\Http\Request;
 
 class APIController extends Controller
 {
-    public function getQRCode(Request $request)
-    {
-        $url = 'https://getqrcode.p.rapidapi.com/api/getQR';
-        $queryParams = [
-            'forQR' => $request->input('http://new-composer-app.test/productos/3/editar'),
-        ];
-        $headers = [
-            'X-RapidAPI-Key' =>  env('X_RAPID_API_KEY'),
-            'X-RapidAPI-Host' => 'getqrcode.p.rapidapi.com',
-        ];
-
-        try {
-            $client = new Client();
-            $response = $client->request('GET', $url, [
-                'query' => $queryParams,
-                'headers' => $headers,
-            ]);
-
-            $result = $response->getBody()->getContents();
-            return $result;
-        } catch (\Exception $e) {
-            return response()->json(['error' => $e->getMessage()], 500);
-        }
-    }
-
     public function showImage($id)
     {
         $image = Images::findOrFail($id);
@@ -42,5 +16,4 @@ class APIController extends Controller
 
         return redirect($image->url);
     }
-
 }

--- a/app/Http/Controllers/ProductosController.php
+++ b/app/Http/Controllers/ProductosController.php
@@ -12,14 +12,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
-use GuzzleHttp\Client;
-use CloudinaryLabs\CloudinaryLaravel\Facades\Cloudinary;
-use GuzzleHttp\Psr7\Response;
-use Illuminate\Http\Response as IlluminateResponse;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Http\Testing\FileFactory;
-use Illuminate\Http\File;
-use Illuminate\Support\Facades\Storage;
 
 class ProductosController extends Controller
 {
@@ -74,10 +66,10 @@ class ProductosController extends Controller
             }
             DB::commit();
             $estado = new Estados();
-            $estado->id_producto =$idProducto;
-            $estado->descripcion = "producto registrado"; // Valor por defecto
-            $estado->save(); 
-            $this->requestQRCode($idProducto);
+            $estado->id_producto = $idProducto;
+            $estado->descripcion = 'producto registrado';
+            $estado->save();
+
             return redirect('/productos')->with('success', 'Producto creado correctamente');
         } catch (\Exception $e) {
             DB::rollBack();
@@ -304,51 +296,7 @@ class ProductosController extends Controller
 
     }
 
-    public function requestQRCode(string $id)
-    {
-        //$productURL='http://new-composer-app.test/productos/'.$id;
-        $productURL= env('APP_URL') . '/productos/' . $id;
-        $urlAPI = 'https://getqrcode.p.rapidapi.com/api/getQR';
-        $queryParams = [
-            'forQR' => $productURL,
-        ];
-        $headers = [
-            'X-RapidAPI-Key' => env('X_RAPID_API_KEY'),
-            'X-RapidAPI-Host' => 'getqrcode.p.rapidapi.com',
-        ];
-
-        try {
-            $client = new Client();
-            $response = $client->request('GET', $urlAPI, [
-                'query' => $queryParams,
-                'headers' => $headers,
-            ]);
-           $result = $response->getBody()->getContents();
-           $this->uploadFile($result, $id); 
-        } catch (\Exception $e) {
-            return redirect()->back()->with('error', 'Error al generar el código QR: ' . $e->getMessage());
-        }
-    }
-
-    public function uploadFile($file, $id_upload) 
-    {
-        try {
-        $archivoTemporal = tempnam(sys_get_temp_dir(), 'archivo_temporal');
-        file_put_contents($archivoTemporal, $file);
-    
-        // Subir el archivo a Cloudinary
-        $cloudinaryResponse = Cloudinary::upload($archivoTemporal)->getSecurePath();
-
-        $this->saveQR( $cloudinaryResponse, $id_upload);
-    
-        // Eliminar el archivo temporal
-        unlink($archivoTemporal);
-     } catch (\Exception $e) {
-         return redirect()->back()->with('error', 'Error al subir archivo: ' . $e->getMessage());
-     }
-    }
-
-    public function getStatus($id_producto) 
+    public function getStatus($id_producto)
     {
         $status = Estados::where('id_producto', $id_producto)->get();
         
@@ -382,16 +330,4 @@ class ProductosController extends Controller
         }
     }
 
-    public function saveQR ($url, $id_upload) {
-        try {
-            $image = new Images([
-                'nombre' => 'QR_Producto',
-                'url' => $url,
-                'id_producto' =>  $id_upload,
-            ]);
-            $image->save();
-            } catch (\Exception $e) {
-                return redirect()->back()->with('error', 'Error al guardar imagen QR: ' . $e->getMessage());
-            }
-    } 
 }

--- a/app/Http/Controllers/QrCodeController.php
+++ b/app/Http/Controllers/QrCodeController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Productos;
+use App\Services\QrCodeService;
+use Illuminate\Http\Response;
+
+class QrCodeController extends Controller
+{
+    public function __construct(private readonly QrCodeService $qrService)
+    {
+    }
+
+    public function svg(string $id): Response
+    {
+        $producto = $this->resolveProducto($id);
+
+        return response($this->qrService->svg($this->productoUrl($producto)), 200)
+            ->header('Content-Type', 'image/svg+xml')
+            ->header('Cache-Control', 'private, max-age=3600');
+    }
+
+    public function png(string $id): Response
+    {
+        $producto = $this->resolveProducto($id);
+
+        return response($this->qrService->png($this->productoUrl($producto)), 200)
+            ->header('Content-Type', 'image/png')
+            ->header('Cache-Control', 'private, max-age=3600');
+    }
+
+    private function resolveProducto(string $id): Productos
+    {
+        $producto = Productos::findOrFail($id);
+        abort_if($producto->id_user !== auth()->id(), 403);
+
+        return $producto;
+    }
+
+    private function productoUrl(Productos $producto): string
+    {
+        return url('/productos/' . $producto->id);
+    }
+}

--- a/app/Services/QrCodeService.php
+++ b/app/Services/QrCodeService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services;
+
+use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\Color\Color;
+use Endroid\QrCode\ErrorCorrectionLevel;
+use Endroid\QrCode\Writer\PngWriter;
+use Endroid\QrCode\Writer\SvgWriter;
+
+class QrCodeService
+{
+    public function svg(string $data, int $size = 300): string
+    {
+        $builder = new Builder(
+            writer: new SvgWriter(),
+            data: $data,
+            size: $size,
+            margin: 10,
+            errorCorrectionLevel: ErrorCorrectionLevel::Medium,
+            foregroundColor: new Color(11, 15, 20),
+            backgroundColor: new Color(255, 255, 255),
+        );
+
+        return $builder->build()->getString();
+    }
+
+    public function png(string $data, int $size = 600): string
+    {
+        $builder = new Builder(
+            writer: new PngWriter(),
+            data: $data,
+            size: $size,
+            margin: 10,
+            errorCorrectionLevel: ErrorCorrectionLevel::Medium,
+            foregroundColor: new Color(11, 15, 20),
+            backgroundColor: new Color(255, 255, 255),
+        );
+
+        return $builder->build()->getString();
+    }
+}

--- a/resources/views/panels/productTable.blade.php
+++ b/resources/views/panels/productTable.blade.php
@@ -10,10 +10,7 @@
                             alt="Producto" style="width: 15rem;" 
                         >
                     </a>
-                    @php
-                            $imagenProducto = $imagenes->where('id_producto', $row->id)->first();
-                        @endphp
-                        <button type="button" class="btn btn-primary w-100" data-bs-toggle="modal" data-bs-target="#imagenModal">
+                        <button type="button" class="btn btn-primary w-100" data-bs-toggle="modal" data-bs-target="#imagenModal-{{ $row->id }}">
                           Ver código QR
                         </button>
                     <div class="card-body">
@@ -59,8 +56,8 @@
                                 <i class="fa-solid fa-pen text-secondary fs-4"></i>
                             </a>
                             <div class="col-6 text-center">
-                                <button type="button" class="btn" data-bs-toggle="modal" 
-                                    data-bs-target="#exampleModal"
+                                <button type="button" class="btn" data-bs-toggle="modal"
+                                    data-bs-target="#exampleModal-{{ $row->id }}"
                                 >
                                     <i class="fa-solid fa-trash-can text-secondary fs-4"></i>
                                 </button>
@@ -69,7 +66,7 @@
                     </div>
                 </div>
             </div>
-            <div class="modal fade" id="exampleModal" tabindex="-1" 
+            <div class="modal fade" id="exampleModal-{{ $row->id }}" tabindex="-1"
                 aria-labelledby="exampleModalLabel" aria-hidden="true"
             >
                 <div class="modal-dialog">
@@ -104,14 +101,15 @@
                 </div>
             </div>
 
-            <div class="modal fade" id="imagenModal" tabindex="-1" role="dialog" aria-labelledby="imagenModalLabel" aria-hidden="true">
+            <div class="modal fade" id="imagenModal-{{ $row->id }}" tabindex="-1" role="dialog" aria-labelledby="imagenModalLabel-{{ $row->id }}" aria-hidden="true">
               <div class="modal-dialog" role="document">
                 <div class="modal-content">
                   <div class="modal-body text-center">
-                    <img src="{{$imagenProducto->url ?? asset('img/pack.png')}}" alt="Código QR del producto" id="imagenProducto" class="img-fluid">
+                    <img src="{{ route('producto.qr.svg', $row->id) }}" alt="Código QR de {{ $row->nombre }}" class="img-fluid" loading="lazy">
                   </div>
                   <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Regresar</button>
+                    <a href="{{ route('producto.qr.png', $row->id) }}" download="qr-{{ $row->id }}.png" class="btn btn-outline-secondary">Descargar PNG</a>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
                   </div>
                 </div>
               </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\AlmacenesController;
 use App\Http\Controllers\MainController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\APIController;
+use App\Http\Controllers\QrCodeController;
 use Illuminate\Http\Request;
 
 
@@ -44,6 +45,8 @@ Route::get('productos/{id}/editar', [ProductosController::class, 'edit'])->middl
 Route::put('productos/{id}/editar', [ProductosController::class, 'update'])->middleware('auth');;
 //Route::get('productos/{id}', [ProductosController::class, 'display'])->middleware('auth');;
 Route::delete('productos/{id}', [ProductosController::class, 'destroy'])->middleware('auth');;
+Route::get('productos/{id}/qr.svg', [QrCodeController::class, 'svg'])->middleware('auth')->name('producto.qr.svg');
+Route::get('productos/{id}/qr.png', [QrCodeController::class, 'png'])->middleware('auth')->name('producto.qr.png');
 
 //Rutas de Almacenes
 Route::get('/almacenes', [AlmacenesController::class, 'index'])->middleware('auth');;
@@ -77,7 +80,6 @@ Route::get('/private', [UserController::class, 'show'])->middleware('auth');
 Route::post('/private', [UserController::class, 'sendWelcomeEmail'])->name('enviar-bienvenida');
 Route::delete('/private', [UserController::class, 'destroy'])->middleware('auth');
 
-Route::get('/getQRCode', [APIController::class, 'getQRCode'])->middleware(['auth', 'throttle:10,1']);
 Route::get('/images/{id}', [APIController::class, 'showImage'])->middleware('auth');
 
 Route::get('/qrscanner', function () {

--- a/tests/Feature/QrCodeTest.php
+++ b/tests/Feature/QrCodeTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Almacenes;
+use App\Models\Productos;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class QrCodeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_gets_svg_qr_code(): void
+    {
+        Http::preventStrayRequests();
+
+        $user = User::factory()->create();
+        $almacen = Almacenes::factory()->create(['id_user' => $user->id]);
+        $producto = Productos::factory()->create([
+            'id_user' => $user->id,
+            'almacen' => $almacen->id,
+        ]);
+
+        $response = $this->actingAs($user)->get("/productos/{$producto->id}/qr.svg");
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'image/svg+xml');
+        $this->assertStringContainsString('<svg', $response->getContent());
+    }
+
+    public function test_owner_gets_png_qr_code(): void
+    {
+        Http::preventStrayRequests();
+
+        $user = User::factory()->create();
+        $almacen = Almacenes::factory()->create(['id_user' => $user->id]);
+        $producto = Productos::factory()->create([
+            'id_user' => $user->id,
+            'almacen' => $almacen->id,
+        ]);
+
+        $response = $this->actingAs($user)->get("/productos/{$producto->id}/qr.png");
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'image/png');
+        $this->assertStringStartsWith("\x89PNG", $response->getContent());
+    }
+
+    public function test_foreign_user_cannot_access_qr_code(): void
+    {
+        $owner = User::factory()->create();
+        $stranger = User::factory()->create();
+        $almacen = Almacenes::factory()->create(['id_user' => $owner->id]);
+        $producto = Productos::factory()->create([
+            'id_user' => $owner->id,
+            'almacen' => $almacen->id,
+        ]);
+
+        $this->actingAs($stranger)->get("/productos/{$producto->id}/qr.svg")->assertForbidden();
+    }
+
+    public function test_qr_code_endpoint_does_not_call_external_apis(): void
+    {
+        Http::preventStrayRequests();
+
+        $user = User::factory()->create();
+        $almacen = Almacenes::factory()->create(['id_user' => $user->id]);
+        $producto = Productos::factory()->create([
+            'id_user' => $user->id,
+            'almacen' => $almacen->id,
+        ]);
+
+        $this->actingAs($user)->get("/productos/{$producto->id}/qr.svg")->assertOk();
+
+        Http::assertNothingSent();
+    }
+}


### PR DESCRIPTION
## Resumen

Sustituye la generación de QR vía API externa de pago (RapidAPI) + upload a Cloudinary por **generación local con `endroid/qr-code`** (ya en `composer.json`). **Base: \`work/cross-tenant-fix\` (PR #14)**.

### Por qué importa

- **Coste cero** por QR generado (antes cada producto consumía 1 crédito RapidAPI + 1 upload Cloudinary).
- **Sin dependencias externas** que puedan caer o filtrar URLs.
- **Bloqueo previo al modo demo** (F13.5): un visitante demo creando 50 productos quemaría la cuota del cliente.
- **Privacidad**: el QR ya no viaja a un tercer servicio antes de mostrarse.

### Cambios

- **`App\Services\QrCodeService`**: wrapper sobre endroid 6 con `svg(string $url, int $size)` y `png(string $url, int $size)`. Color foreground `#0B0F14` (token `ink-950` del design system), background blanco, ECC nivel Medium.
- **`App\Http\Controllers\QrCodeController`**: dos endpoints nuevos
  - `GET /productos/{id}/qr.svg` (named: `producto.qr.svg`)
  - `GET /productos/{id}/qr.png` (named: `producto.qr.png`)
  - Ambos: `auth` + `abort_if($producto->id_user !== auth()->id(), 403)` + `Cache-Control: private, max-age=3600`.
- **`ProductosController`**: eliminados `requestQRCode`, `uploadFile`, `saveQR`. Limpiados imports de Guzzle/Cloudinary/Storage. `store()` ya no llama a la API externa.
- **`APIController`**: eliminado `getQRCode` (RapidAPI). Solo queda `showImage` con ownership check.
- **`routes/web.php`**: eliminada `GET /getQRCode`. Añadidas las dos rutas nuevas.
- **Vista `productTable.blade.php`**:
  - QR ahora se sirve desde `route('producto.qr.svg', $row->id)`
  - Botón "Descargar PNG" añadido al modal del QR
  - **Bug fix**: el `id="imagenModal"` y `id="exampleModal"` colisionaban entre los `@foreach`; ahora son únicos por producto (`#imagenModal-{id}`, `#exampleModal-{id}`)
  - Texto modal "Regresar" → "Cerrar" (más estándar)
- **Tests Feature** (4):
  - Owner recibe SVG válido (Content-Type + `<svg`)
  - Owner recibe PNG válido (header magic bytes `\x89PNG`)
  - Foreign user → 403
  - El endpoint NO realiza llamadas HTTP externas (`Http::preventStrayRequests()` + `Http::assertNothingSent()`)

### Lo que queda
- La columna `productos.qr` (`Str::random(10)`) sigue creándose pero **ya no se usa** en URLs ni vistas. La eliminaré en una migración limpia tras F7 cuando sepa con seguridad que no quedan referencias.
- Cloudinary se mantiene en composer **solo** para fotos reales del producto (F7). El upload de QR a Cloudinary queda fuera.

## Test plan

- [ ] CI verde sobre PR #14
- [ ] Tras mergear: el modal de "Ver código QR" muestra el SVG generado al vuelo
- [ ] El QR escaneado lleva a `/productos/{id}` (auth gated)
- [ ] Crear producto con `php artisan tinker` no falla (antes la creación llamaba a RapidAPI; si la key estaba mal, fallaba)

🤖 Generated with [Claude Code](https://claude.com/claude-code)