### PR TITLE
ops: keep-alive de Render free tier + endpoint /healthz

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,32 @@
+name: Keep Render awake
+
+# Render free tier duerme la app tras ~15 min sin tráfico.
+# Hacemos un ping ligero cada 10 min en horas laborales (UTC 06:00-22:59 ≈ 08:00-00:59 CET).
+# /healthz es un endpoint sin BD ni auth — coste mínimo en cómputo.
+
+on:
+  schedule:
+    - cron: '*/10 6-22 * * *'
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping /healthz
+        run: |
+          URL="${KEEP_ALIVE_URL:-https://c-depot.onrender.com/healthz}"
+          echo "Pinging $URL"
+          for i in 1 2 3; do
+            STATUS=$(curl -s -o /tmp/body -w "%{http_code}" --max-time 30 "$URL" || echo "000")
+            echo "Attempt $i — status $STATUS"
+            if [ "$STATUS" = "200" ]; then
+              cat /tmp/body
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Ping failed after 3 attempts"
+          exit 1
+        env:
+          KEEP_ALIVE_URL: ${{ vars.KEEP_ALIVE_URL }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,12 @@ use Illuminate\Http\Request;
 |
 */
 
+// Health check: 200 OK ligero usado por keep-alive y monitoring.
+Route::get('/healthz', fn () => response('ok', 200, [
+    'Content-Type' => 'text/plain',
+    'X-Robots-Tag' => 'noindex, nofollow',
+]))->name('healthz');
+
 //Ruta de Home - Redirige a login si no está autenticado
 Route::get('/', function() {
     if (auth()->check()) {

--- a/tests/Feature/SmokeTest.php
+++ b/tests/Feature/SmokeTest.php
@@ -31,4 +31,13 @@ class SmokeTest extends TestCase
         $this->get('/categorias')->assertRedirect('/login');
         $this->get('/qrscanner')->assertRedirect('/login');
     }
+
+    public function test_healthz_returns_ok_without_auth(): void
+    {
+        $response = $this->get('/healthz');
+
+        $response->assertOk();
+        $this->assertSame('ok', $response->getContent());
+        $response->assertHeader('X-Robots-Tag', 'noindex, nofollow');
+    }
 }


### PR DESCRIPTION
## Resumen

Mantiene la app **C-DEPOT** despierta en Render free tier (que se duerme tras ~15 min de inactividad).

### Cambios

- **`GET /healthz`** — endpoint nuevo, público, sin auth ni acceso a BD. Devuelve `200 OK` + cuerpo `ok` + header `X-Robots-Tag: noindex, nofollow`. Sirve también para monitoring externo y health checks de Render.
- **`.github/workflows/keep-alive.yml`** — cron `*/10 6-22 * * *` (UTC). En CET ≈ 08:00–00:59. Total ~102 pings/día (no las 144 de un cron 24/7).
  - Reintentos con backoff: 3 intentos, sleep 5s entre ellos.
  - Configurable vía `vars.KEEP_ALIVE_URL` en repo settings (default: `https://c-depot.onrender.com/healthz`).
  - `workflow_dispatch` para triggear manualmente desde la UI de Actions.
- **Test Feature**: `/healthz` devuelve 200 sin auth y respeta header `noindex`.

### Por qué cron entre 06:00–22:59 UTC y no 24/7

- Render se duerme tras 15 min sin tráfico, **no se duerme** con tráfico real diurno.
- En horario nocturno CET (~01:00–07:00) hay menos probabilidad de uso humano. Se permite que duerma.
- Reduce 30% el consumo de minutos del runner gratuito de GitHub Actions.

### Configuración manual recomendada

Si la URL de producción cambia, define una variable de repo:
- `Settings → Secrets and variables → Actions → Variables → New variable`
- Nombre: `KEEP_ALIVE_URL`, valor: `https://tu-dominio/healthz`

## Test plan

- [ ] CI verde
- [ ] Tras merge: ir a `Actions → Keep Render awake → Run workflow` y verificar status 200
- [ ] Esperar 1h: confirmar que el primer hit a la app no tiene tiempo de cold start

🤖 Generated with [Claude Code](https://claude.com/claude-code)